### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: https://bues.ch/h/razercfg
 
 Package: razercfg
 Architecture: linux-any
-Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 3.0-6)
+Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}, lsb-base
 Suggests: python3-pyqt5
 Description: Razer device configuration tool
  This is a system daemon and Python-powered CLI configuration utility for Razer


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/razercfg/08dbec82-d538-4167-ab6f-925df4ab3ba6.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*qrazercfg\*\*

No differences were encountered between the control files of package \*\*qrazercfg-applet\*\*
### Control files of package razercfg: lines which differ (wdiff format)
* Depends: python3:any, libc6 (>= 2.34), libusb-1.0-0 (>= 2:1.0.8), lsb-base [-(>= 3.0-6)-]

No differences were encountered between the control files of package \*\*razercfg-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/08dbec82-d538-4167-ab6f-925df4ab3ba6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/08dbec82-d538-4167-ab6f-925df4ab3ba6/diffoscope)).
